### PR TITLE
Version 10.1.0 - Bump package versions from 10.0.0 to 10.1.0

### DIFF
--- a/src/Demo.WebApp/Demo.WebApp.csproj
+++ b/src/Demo.WebApp/Demo.WebApp.csproj
@@ -32,7 +32,7 @@
     <PackageReference Include="cloudscribe.Core.Storage.EFCore.SQLite" Version="10.0.0" />
     <PackageReference Include="cloudscribe.Core.Storage.NoDb" Version="10.0.0" />
 
-    <PackageReference Include="cloudscribe.Web.Localization" Version="10.0.0" />
+    <PackageReference Include="cloudscribe.Web.Localization" Version="10.1.0" />
     <PackageReference Include="cloudscribe.Web.StaticFiles" Version="10.0.0" />
   </ItemGroup>
 

--- a/src/cloudscribe.Logging.EFCore.Common/cloudscribe.Logging.EFCore.Common.csproj
+++ b/src/cloudscribe.Logging.EFCore.Common/cloudscribe.Logging.EFCore.Common.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Entity Framework Core implementation of cloudscribe ILogRepository</Description>
-    <Version>10.0.0</Version>
+    <Version>10.1.0</Version>
     <TargetFramework>net10.0</TargetFramework>
     <Authors>Joe Audette</Authors>
     <PackageTags>cloudscribe;repositories;logging</PackageTags>

--- a/src/cloudscribe.Logging.EFCore.MSSQL/cloudscribe.Logging.EFCore.MSSQL.csproj
+++ b/src/cloudscribe.Logging.EFCore.MSSQL/cloudscribe.Logging.EFCore.MSSQL.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>MSSQL Entity Framework Core implementation of cloudscribe ILogRepository</Description>
-    <Version>10.0.0</Version>
+    <Version>10.1.0</Version>
     <TargetFramework>net10.0</TargetFramework>
     <Authors>Joe Audette</Authors>
     <PackageTags>cloudscribe;repositories;logging</PackageTags>

--- a/src/cloudscribe.Logging.EFCore.MySql/cloudscribe.Logging.EFCore.MySql.csproj
+++ b/src/cloudscribe.Logging.EFCore.MySql/cloudscribe.Logging.EFCore.MySql.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>MySQL Entity Framework Core implementation of cloudscribe ILogRepository</Description>
-    <Version>10.0.0</Version>
+    <Version>10.1.0</Version>
     <TargetFramework>net10.0</TargetFramework>
     <Authors>Joe Audette</Authors>
     <PackageTags>cloudscribe;repositories;logging</PackageTags>

--- a/src/cloudscribe.Logging.EFCore.PostgreSql/cloudscribe.Logging.EFCore.PostgreSql.csproj
+++ b/src/cloudscribe.Logging.EFCore.PostgreSql/cloudscribe.Logging.EFCore.PostgreSql.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>PostgreSql Entity Framework Core implementation of cloudscribe ILogRepository, using snake case tables and fields</Description>
-    <Version>10.0.0</Version>
+    <Version>10.1.0</Version>
     <TargetFramework>net10.0</TargetFramework>
     <Authors>Joe Audette</Authors>
     <PackageTags>cloudscribe;repositories;logging</PackageTags>

--- a/src/cloudscribe.Logging.EFCore.SQLite/cloudscribe.Logging.EFCore.SQLite.csproj
+++ b/src/cloudscribe.Logging.EFCore.SQLite/cloudscribe.Logging.EFCore.SQLite.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>SQLite Entity Framework Core implementation of cloudscribe ILogRepository</Description>
-    <Version>10.0.0</Version>
+    <Version>10.1.0</Version>
     <TargetFramework>net10.0</TargetFramework>
     <Authors>Joe Audette</Authors>
     <PackageTags>cloudscribe;repositories;logging</PackageTags>

--- a/src/cloudscribe.Logging.NoDb/cloudscribe.Logging.NoDb.csproj
+++ b/src/cloudscribe.Logging.NoDb/cloudscribe.Logging.NoDb.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>NoDb implementation of cloudscribe ILogRepository</Description>
-    <Version>10.0.0</Version>
+    <Version>10.1.0</Version>
     <TargetFramework>net10.0</TargetFramework>
     <Authors>Joe Audette</Authors>
     <PackageTags>cloudscribe;repositories;logging</PackageTags>

--- a/src/cloudscribe.Logging.Web/cloudscribe.Logging.Web.csproj
+++ b/src/cloudscribe.Logging.Web/cloudscribe.Logging.Web.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>An implementation of ILogger and ILoggerProvider that logs to the database using a pluggable model supporting multiple data platforms. Also proivides an MVC controller for viewing and managing the log data.</Description>
-    <Version>10.0.0</Version>
+    <Version>10.1.0</Version>
     <TargetFramework>net10.0</TargetFramework>
     <Authors>Joe Audette</Authors>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
@@ -36,7 +36,7 @@
   <ItemGroup>
     <PackageReference Include="cloudscribe.Versioning" Version="10.0.0" />
     <PackageReference Include="cloudscribe.DateTimeUtils" Version="10.0.0" />
-    <PackageReference Include="cloudscribe.Web.Pagination" Version="10.0.0" />
+    <PackageReference Include="cloudscribe.Web.Pagination" Version="10.1.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Localization" Version="10.0.0" />

--- a/src/cloudscribe.Logging/cloudscribe.Logging.csproj
+++ b/src/cloudscribe.Logging/cloudscribe.Logging.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>An implementation of ILogger and ILoggerProvider that logs to the database using a pluggable model supporting multiple data platforms. Also proivides an MVC controller for viewing and managing the log data.</Description>
-    <Version>10.0.0</Version>
+    <Version>10.1.0</Version>
     <TargetFramework>net10.0</TargetFramework>
     <Authors>Joe Audette</Authors>
     <PackageTags>cloudscribe;logging;database</PackageTags>
@@ -25,7 +25,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
     
-    <PackageReference Include="cloudscribe.Pagination.Models" Version="10.0.0" />
+    <PackageReference Include="cloudscribe.Pagination.Models" Version="10.1.0" />
     <PackageReference Include="NewtonSoft.Json" Version="13.0.3" />
   </ItemGroup>
 

--- a/update_version.ps1
+++ b/update_version.ps1
@@ -16,9 +16,9 @@
 $directory = "src"
 
 # Define the old & new versions
-$oldVersion = '8\.7'   # slash needed !
-$newVersion = "8.8.0"
-$newWildcardVersion = "8.8.*"
+$oldVersion = '10\.0'   # slash needed !
+$newVersion = "10.1.0"
+$newWildcardVersion = "10.1.*"
 	
 
 # Get all .csproj files in the directory and subdirectories


### PR DESCRIPTION
## Summary

This PR bumps all cloudscribe.Logging package versions from **10.0.0** to **10.1.0** as part of the coordinated v10.1 release campaign across the cloudscribe ecosystem.

## Changes

**Version updates applied to 10 .csproj files:**

### Core Library
- `src/cloudscribe.Logging/cloudscribe.Logging.csproj`

### Web UI Layer
- `src/cloudscribe.Logging.Web/cloudscribe.Logging.Web.csproj`

### Storage Providers
- `src/cloudscribe.Logging.NoDb/cloudscribe.Logging.NoDb.csproj`
- `src/cloudscribe.Logging.EFCore.Common/cloudscribe.Logging.EFCore.Common.csproj`
- `src/cloudscribe.Logging.EFCore.MSSQL/cloudscribe.Logging.EFCore.MSSQL.csproj`
- `src/cloudscribe.Logging.EFCore.MySql/cloudscribe.Logging.EFCore.MySql.csproj`
- `src/cloudscribe.Logging.EFCore.PostgreSql/cloudscribe.Logging.EFCore.PostgreSql.csproj`
- `src/cloudscribe.Logging.EFCore.SQLite/cloudscribe.Logging.EFCore.SQLite.csproj`

### Demo Applications
- `src/Demo.WebApp/Demo.WebApp.csproj`

### Build Script
- `update_version.ps1` - Updated version variables from 10.0→10.1

## Important Notes

⚠️ **Dependency Handling**: Some cloudscribe package references were intentionally kept at version **10.0.0** because they haven't been published at version 10.1.0 yet:
- `cloudscribe.Versioning` (kept at 10.0.0)
- `cloudscribe.DateTimeUtils` (kept at 10.0.0)
- `cloudscribe.Core.*` packages (kept at 10.0.0)
- `cloudscribe.Web.StaticFiles` (kept at 10.0.0)

These will need to be updated to 10.1.0 **after** the cloudscribe main repository (repo #5) publishes its v10.1.0 packages to NuGet.

## Build Status

✅ Build succeeded with warnings only (NU1510 package pruning, NU1608 Pomelo MySQL constraints, CS8981 migration naming - all acceptable)

## Process

This version bump was performed using the standard process:
1. ✅ Created `version_10.1` branch
2. ✅ Modified `update_version.ps1` (10.0→10.1)
3. ✅ Executed PowerShell script
4. ✅ Manually reverted unpublished dependency versions to 10.0.0
5. ✅ Build validation passed
6. ✅ Committed changes
7. ✅ Pushed to remote

---

🤖 *Generated and committed by Claude (Anthropic AI Assistant) as part of the cloudscribe v10.1 version bump campaign*