### PR TITLE
Update cloudscribe Core dependencies to 10.1.0 (follow-up to PR #71)

### DIFF
--- a/src/Demo.WebApp/Demo.WebApp.csproj
+++ b/src/Demo.WebApp/Demo.WebApp.csproj
@@ -24,16 +24,16 @@
   </ItemGroup>
 
   <ItemGroup Label="Package References">
-    <PackageReference Include="cloudscribe.Core.Web" Version="10.0.*" />
-    <PackageReference Include="cloudscribe.Core.CompiledViews.Bootstrap5" Version="10.0.0" />
-    <PackageReference Include="cloudscribe.Core.Storage.EFCore.MSSQL" Version="10.0.0" />
-    <PackageReference Include="cloudscribe.Core.Storage.EFCore.MySql" Version="10.0.0" />
-    <PackageReference Include="cloudscribe.Core.Storage.EFCore.PostgreSql" Version="10.0.0" />
-    <PackageReference Include="cloudscribe.Core.Storage.EFCore.SQLite" Version="10.0.0" />
-    <PackageReference Include="cloudscribe.Core.Storage.NoDb" Version="10.0.0" />
+    <PackageReference Include="cloudscribe.Core.Web" Version="10.1.*" />
+    <PackageReference Include="cloudscribe.Core.CompiledViews.Bootstrap5" Version="10.1.0" />
+    <PackageReference Include="cloudscribe.Core.Storage.EFCore.MSSQL" Version="10.1.0" />
+    <PackageReference Include="cloudscribe.Core.Storage.EFCore.MySql" Version="10.1.0" />
+    <PackageReference Include="cloudscribe.Core.Storage.EFCore.PostgreSql" Version="10.1.0" />
+    <PackageReference Include="cloudscribe.Core.Storage.EFCore.SQLite" Version="10.1.0" />
+    <PackageReference Include="cloudscribe.Core.Storage.NoDb" Version="10.1.0" />
 
     <PackageReference Include="cloudscribe.Web.Localization" Version="10.1.0" />
-    <PackageReference Include="cloudscribe.Web.StaticFiles" Version="10.0.0" />
+    <PackageReference Include="cloudscribe.Web.StaticFiles" Version="10.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/cloudscribe.Logging.EFCore.MSSQL/cloudscribe.Logging.EFCore.MSSQL.csproj
+++ b/src/cloudscribe.Logging.EFCore.MSSQL/cloudscribe.Logging.EFCore.MSSQL.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="cloudscribe.Versioning" Version="10.0.0" /> 
+    <PackageReference Include="cloudscribe.Versioning" Version="10.1.0" /> 
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.0" />

--- a/src/cloudscribe.Logging.EFCore.MySql/cloudscribe.Logging.EFCore.MySql.csproj
+++ b/src/cloudscribe.Logging.EFCore.MySql/cloudscribe.Logging.EFCore.MySql.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="cloudscribe.Versioning" Version="10.0.0" />
+    <PackageReference Include="cloudscribe.Versioning" Version="10.1.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.0" />

--- a/src/cloudscribe.Logging.EFCore.PostgreSql/cloudscribe.Logging.EFCore.PostgreSql.csproj
+++ b/src/cloudscribe.Logging.EFCore.PostgreSql/cloudscribe.Logging.EFCore.PostgreSql.csproj
@@ -28,7 +28,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="cloudscribe.Versioning" Version="10.0.0" />
+    <PackageReference Include="cloudscribe.Versioning" Version="10.1.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />

--- a/src/cloudscribe.Logging.EFCore.SQLite/cloudscribe.Logging.EFCore.SQLite.csproj
+++ b/src/cloudscribe.Logging.EFCore.SQLite/cloudscribe.Logging.EFCore.SQLite.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="cloudscribe.Versioning" Version="10.0.0" />
+    <PackageReference Include="cloudscribe.Versioning" Version="10.1.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.0" />

--- a/src/cloudscribe.Logging.NoDb/cloudscribe.Logging.NoDb.csproj
+++ b/src/cloudscribe.Logging.NoDb/cloudscribe.Logging.NoDb.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="cloudscribe.Versioning" Version="10.0.0" />
+    <PackageReference Include="cloudscribe.Versioning" Version="10.1.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.0" />
     

--- a/src/cloudscribe.Logging.Web/cloudscribe.Logging.Web.csproj
+++ b/src/cloudscribe.Logging.Web/cloudscribe.Logging.Web.csproj
@@ -34,8 +34,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="cloudscribe.Versioning" Version="10.0.0" />
-    <PackageReference Include="cloudscribe.DateTimeUtils" Version="10.0.0" />
+    <PackageReference Include="cloudscribe.Versioning" Version="10.1.0" />
+    <PackageReference Include="cloudscribe.DateTimeUtils" Version="10.1.0" />
     <PackageReference Include="cloudscribe.Web.Pagination" Version="10.1.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="10.0.0" />


### PR DESCRIPTION
## Summary

This PR corrects cloudscribe package dependency versions that were mistakenly kept at **10.0.0** in PR #71. These packages are now updated to **10.1.0** to align with the published versions in the Nexus testing repository.

## Background

PR #71 intentionally kept some cloudscribe package references at 10.0.0 because we believed the cloudscribe main repository (#5) packages hadn't been published at 10.1.0 yet. However, PR #1283 for the cloudscribe main repo had already been merged and the CI pipeline had published those packages to the Nexus testing repository at version 10.1.0.

## Changes

**Package version updates (10.0.0 → 10.1.0):**
- `cloudscribe.Versioning`
- `cloudscribe.DateTimeUtils`
- `cloudscribe.Core.Web` (10.0.* → 10.1.*)
- `cloudscribe.Core.CompiledViews.Bootstrap5`
- `cloudscribe.Core.Storage.EFCore.MSSQL`
- `cloudscribe.Core.Storage.EFCore.MySql`
- `cloudscribe.Core.Storage.EFCore.PostgreSql`
- `cloudscribe.Core.Storage.EFCore.SQLite`
- `cloudscribe.Core.Storage.NoDb`
- `cloudscribe.Web.StaticFiles`

**Files modified (7):**
- `src/cloudscribe.Logging.Web/cloudscribe.Logging.Web.csproj`
- `src/cloudscribe.Logging.NoDb/cloudscribe.Logging.NoDb.csproj`
- `src/cloudscribe.Logging.EFCore.MSSQL/cloudscribe.Logging.EFCore.MSSQL.csproj`
- `src/cloudscribe.Logging.EFCore.MySql/cloudscribe.Logging.EFCore.MySql.csproj`
- `src/cloudscribe.Logging.EFCore.PostgreSql/cloudscribe.Logging.EFCore.PostgreSql.csproj`
- `src/cloudscribe.Logging.EFCore.SQLite/cloudscribe.Logging.EFCore.SQLite.csproj`
- `src/Demo.WebApp/Demo.WebApp.csproj`

## Build Status

✅ **Build succeeded** with 22 warnings, 0 errors (same warnings as PR #71):
- NU1510: Package pruning warnings (acceptable)
- NU1608: Pomelo MySQL version constraint warnings (acceptable)
- CS8981: Migration naming warnings (acceptable)

## Testing

The build validates that all cloudscribe 10.1.0 packages are correctly resolved from the Nexus testing repository at `https://nexus2.esdm.co.uk/repository/ESDM-nuget-testing/`.

---

🤖 *Generated and committed by Claude (Anthropic AI Assistant) - Follow-up fix for cloudscribe v10.1 version bump campaign*